### PR TITLE
Update api.php

### DIFF
--- a/api.php
+++ b/api.php
@@ -50,6 +50,19 @@ class CyberApi
         return $result;
     }
 
+    public function delete_user($params)
+    {
+        $url = "submitUserDeletion";
+        $postParams =
+            [
+                "adminUser" => $params["serverusername"],
+                "adminPass" => $params["serverpassword"],
+                "websiteOwner" => $params["username"],
+            ];
+        $result = $this->call_cyberpanel($params, $url, $postParams);
+        return $result;
+    }	
+	
     public function change_account_status($params)
     {
         $url = "submitWebsiteStatus";


### PR DESCRIPTION
Does not delete the cyberpanel user when terminating account and can then not delete it after the fact as its orphaned.

Then "delete_user" function needs to be called at the end of the terminate_account account part this will need to be added by @jetchirag as not sure best way to do that

Reference:
https://github.com/usmannasir/cyberpanel/blob/v2.0.3-dev/api/urls.py#L17
`  
url(r'^submitUserDeletion$', views.submitUserDeletion, name='submitUserDeletion'),
`
https://github.com/usmannasir/cyberpanel/blob/37e7ef79deeb9181da857d93760d735867689003/api/views.py#L178
```
def submitUserDeletion(request):
    try:
        if request.method == 'POST':

            data = json.loads(request.body)

            adminUser = data['adminUser']
            adminPass = data['adminPass']
```
Errors:
```
(1452, 'Cannot add or update a child row: a foreign key constraint fails (`cyberpanel`.`domains`, CONSTRAINT `domains_admin_id_c9d09cb8_fk_loginSystem_administrator_id` FOREIGN KEY (`admin_id`) REFERENCES `loginSystem_administrator` (`id`))')
```